### PR TITLE
fix(animation-service): corrected position to properly work with rowStart

### DIFF
--- a/projects/ng-dialog-animation/src/lib/ng-dialog-animation.service.ts
+++ b/projects/ng-dialog-animation/src/lib/ng-dialog-animation.service.ts
@@ -64,9 +64,9 @@ export class NgDialogAnimationService {
 
             if (config.position && config.position.rowStart) {
                 if (dir === 'rtl') {
-                    config.position.left = config.position.rowEnd;
+                    config.position.left = config.position.rowStart;
                 } else {
-                    config.position.right = config.position.rowEnd;
+                    config.position.right = config.position.rowStart;
                 }
             }
         }


### PR DESCRIPTION
When using rowStart, modal does not align to the start of the view port. 
e.g. `position: { rowStart: "0" }` 